### PR TITLE
Fixed TopKReducer

### DIFF
--- a/gradient_reducers.py
+++ b/gradient_reducers.py
@@ -228,7 +228,7 @@ class TopKReducer(Reducer):
             flatgrad_size = 0
             tensor_idx = [0]
             for tensor in grad_in:
-                top_size = max(1, int(0.5 * self.rank * tensor.nelement()))
+                top_size = max(1, int(0.5 * self.compression * tensor.nelement()))
                 flatgrad_size += top_size
                 tensor_idx.append(tensor_idx[-1] + top_size)
             flatgrad_start_idx = tensor_idx[:-1]


### PR DESCRIPTION
Code update for Issue #5. 

Corrected the code in TopKReducer class at [this line](https://github.com/epfml/powersgd/blob/3f4eb8d097e9a25ba4fd4b2ff1b2bf83c5aa665a/gradient_reducers.py#L231). Rectified the mistake by updating `self.rank ` with `self.compression`, when calculating `top_size` .