### PR TITLE
Improve performances

### DIFF
--- a/powersgd/powersgd.py
+++ b/powersgd/powersgd.py
@@ -197,10 +197,12 @@ class BasicPowerSGD(Aggregator):
             for group, in_batch, out_batch in zip(
                 shape_groups, out_batches, in_batches
             ):
-                iter_approx = torch.einsum("bnr, bmr -> bmn", out_batch, in_batch)
-                maybe_transpose(group["grad_batch"]).sub_(iter_approx)  # error feedback
-                maybe_transpose(group["approximation"]).add_(iter_approx)
-                del iter_approx
+                torch.bmm(
+                    in_batch, 
+                    out_batch.permute([0, 2, 1]), 
+                    out=maybe_transpose(group["approximation"])
+                )
+                group["grad_batch"].sub_(group["approximation"])  # error feedback
 
         # Un-batch the approximation and error feedback, write to the output
         for group in shape_groups:


### PR DESCRIPTION
Try to address #13

Before:
```
PowerSGD         0.008620023727416992
  Approximation error 285.71148681640625
PowerSGD minimal  0.0014951229095458984
  Approximation error 285.41259765625
SVD low rank     0.0032501220703125
  Approximation error 285.2532043457031
SVD              0.3147141933441162
  Approximation error 285.1278381347656
```

After:
```
PowerSGD         0.004374265670776367
  Approximation error 285.4650573730469
PowerSGD minimal  0.0014731884002685547
  Approximation error 285.1749267578125
SVD low rank     0.00327301025390625
  Approximation error 284.9950256347656
SVD              0.30979394912719727
  Approximation error 284.89654541015625
```

Other overheads are due to batching, computations for error feedback and tensor copies.